### PR TITLE
fix(toggles): properly untoggle indentscope context guide

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -750,6 +750,19 @@ function astrocore.toggles.indent(silent?: boolean)
 
 *param* `silent` — if true then don't sent a notification
 
+### indent_guides
+
+
+```lua
+function astrocore.toggles.indent_guides(bufnr?: number, silent?: boolean)
+```
+
+ Toggle indent guides
+
+*param* `bufnr` — the buffer to toggle indent scope on
+
+*param* `silent` — if true then don't sent a notification
+
 ### notifications
 
 

--- a/doc/astrocore.txt
+++ b/doc/astrocore.txt
@@ -1,4 +1,4 @@
-*astrocore.txt*         For Neovim >= 0.9.0        Last change: 2023 August 19
+*astrocore.txt*         For Neovim >= 0.9.0        Last change: 2023 August 30
 
 ==============================================================================
 Table of Contents                                *astrocore-table-of-contents*
@@ -964,6 +964,19 @@ INDENT ~
 <
 
 Set the indent and tab related numbers
+
+_param_ `silent` — if true then don’t sent a notification
+
+
+INDENT_GUIDES ~
+
+>lua
+    function astrocore.toggles.indent_guides(bufnr?: number, silent?: boolean)
+<
+
+Toggle indent guides
+
+_param_ `bufnr` — the buffer to toggle indent scope on
 
 _param_ `silent` — if true then don’t sent a notification
 

--- a/lua/astrocore/toggles.lua
+++ b/lua/astrocore/toggles.lua
@@ -114,6 +114,19 @@ function M.indent(silent)
   end
 end
 
+--- Toggle indent guides
+---@param bufnr? number the buffer to toggle indent scope on
+---@param silent? boolean if true then don't sent a notification
+function M.indent_guides(bufnr, silent)
+  bufnr = (bufnr and bufnr ~= 0) and bufnr or vim.api.nvim_win_get_buf(0)
+  local indentscope, blankline = "miniindentscope_disable", "indent_blankline_enabled"
+  if vim.b[bufnr][indentscope] == nil then vim.b[bufnr][indentscope] = vim.g[indentscope] end
+  vim.b[bufnr][indentscope] = not vim.b[bufnr][indentscope] -- toggle indentscope
+  vim.b[bufnr][blankline] = not vim.b[bufnr][indentscope] -- get opposite of disabled value
+  pcall(vim.cmd.IndentBlanklineRefresh)
+  ui_notify(silent, string.format("indent guides %s", bool2str(vim.b[bufnr][blankline])))
+end
+
 --- Change the number display modes
 ---@param silent? boolean if true then don't sent a notification
 function M.number(silent)

--- a/lua/astrocore/toggles.lua
+++ b/lua/astrocore/toggles.lua
@@ -123,6 +123,11 @@ function M.buffer_indent_guides(bufnr, silent)
   if vim.b[bufnr][indentscope] == nil then vim.b[bufnr][indentscope] = vim.g[indentscope] end
   vim.b[bufnr][indentscope] = not vim.b[bufnr][indentscope] -- toggle indentscope
   vim.b[bufnr][blankline] = not vim.b[bufnr][indentscope] -- get opposite of disabled value
+  if vim.b[bufnr][indentscope] then
+    require("mini.indentscope").undraw()
+  else
+    require("mini.indentscope").draw()
+  end
   pcall(vim.cmd.IndentBlanklineRefresh)
   ui_notify(silent, string.format("Buffer indent guides %s", bool2str(vim.b[bufnr][blankline])))
 end

--- a/lua/astrocore/toggles.lua
+++ b/lua/astrocore/toggles.lua
@@ -114,17 +114,17 @@ function M.indent(silent)
   end
 end
 
---- Toggle indent guides
+--- Toggle indent guides for a specifc buffer
 ---@param bufnr? number the buffer to toggle indent scope on
 ---@param silent? boolean if true then don't sent a notification
-function M.indent_guides(bufnr, silent)
+function M.buffer_indent_guides(bufnr, silent)
   bufnr = (bufnr and bufnr ~= 0) and bufnr or vim.api.nvim_win_get_buf(0)
   local indentscope, blankline = "miniindentscope_disable", "indent_blankline_enabled"
   if vim.b[bufnr][indentscope] == nil then vim.b[bufnr][indentscope] = vim.g[indentscope] end
   vim.b[bufnr][indentscope] = not vim.b[bufnr][indentscope] -- toggle indentscope
   vim.b[bufnr][blankline] = not vim.b[bufnr][indentscope] -- get opposite of disabled value
   pcall(vim.cmd.IndentBlanklineRefresh)
-  ui_notify(silent, string.format("indent guides %s", bool2str(vim.b[bufnr][blankline])))
+  ui_notify(silent, string.format("Buffer indent guides %s", bool2str(vim.b[bufnr][blankline])))
 end
 
 --- Change the number display modes


### PR DESCRIPTION
## 📑 Description

- Fixes an issue where indentscope is not immediately disabled/enabled on toggle.

- Renames `indent_guides` to `buffer_indent_guides`

## ℹ Additional Information

See https://github.com/AstroNvim/AstroNvim/pull/2260
