### PR TITLE
chore: match the default large buffer size from AstroNvim

### DIFF
--- a/lua/astrocore/config.lua
+++ b/lua/astrocore/config.lua
@@ -309,7 +309,7 @@ local M = {
     cmp = true,
     diagnostics_mode = 3,
     highlighturl = true,
-    large_buf = { size = 1024 * 100, lines = 10000 },
+    large_buf = { size = 1024 * 256, lines = 10000 },
     notifications = true,
   },
   git_worktrees = nil,


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

AstroNvim has changed the default large buffer size, this has been matched with this [commit](https://github.com/AstroNvim/AstroNvim/commit/7ec1742a3d32d519b93397b7d943ffd259389c7a)

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
