### PR TITLE
feat(core): defer clipboard because xsel and pbcopy can be slow

### DIFF
--- a/lua/astrocore/init.lua
+++ b/lua/astrocore/init.lua
@@ -399,6 +399,18 @@ function M.setup(opts)
 
   -- options
   if vim.bo.filetype == "lazy" then vim.cmd.bw() end
+  if M.config.options.opt then
+    -- defer built-in clipboard handling: "xsel" and "pbcopy" can be slow
+    local opt = M.config.options.opt
+    if opt.clipboard then
+      local lazy_clipboard = opt.clipboard
+      opt.clipboard = nil -- clear setting
+      vim.schedule(function() -- runs after UiEnter
+        opt.clipboard = lazy_clipboard -- restore setting
+        vim.opt.clipboard = opt.clipboard
+      end)
+    end
+  end
   for scope, settings in pairs(M.config.options) do
     for setting, value in pairs(settings) do
       vim[scope][setting] = value


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->
See [this](https://github.com/LazyVim/LazyVim/discussions/4112) discussion in LazyVim
Also see [this](https://github.com/LazyVim/LazyVim/pull/4120) pr in LazyVim

TLDR: 
Startup time performance is affected quite significantly when the clipboard provider is `xsel`(linux) or `pbcopy`(macos). I expect an improvement in these cases, especially on older pc's.

This PR makes sure that `vim.opt.clipboard` is only applied after `UiEnter`