### PR TITLE
docs: document support for list of modes for `set_mappings`

### DIFF
--- a/lua/astrocore/config.lua
+++ b/lua/astrocore/config.lua
@@ -12,7 +12,7 @@
 ---@class AstroCoreMapping: vim.api.keyset.keymap
 ---@field [1] AstroCoreMappingCmd? rhs of keymap
 
----@alias AstroCoreMappings table<string,table<string,(AstroCoreMapping|AstroCoreMappingCmd|false)?>?>
+---@alias AstroCoreMappings table<string|table,table<string,(AstroCoreMapping|AstroCoreMappingCmd|false)?>?>
 
 ---@class AstroCoreCommand: vim.api.keyset.user_command
 ---@field [1] string|function the command to execute
@@ -160,7 +160,7 @@
 ---@field filetypes vim.filetype.add.filetypes?
 ---Configuration of vim mappings to create.
 ---The first key into the table is the vim map mode (`:h map-modes`), and the value is a table of entries to be passed to `vim.keymap.set` (`:h vim.keymap.set`):
----  - The key is the first parameter or the vim mode (only a single mode supported) and the value is a table of keymaps within that mode:
+---  - The key is the first parameter or the vim mode and the value is a table of keymaps within that mode:
 ---    - The first element with no key in the table is the action (the 2nd parameter) and the rest of the keys/value pairs are options for the third parameter.
 ---Example:
 --


### PR DESCRIPTION
This also changes the alias definition to match the related parameter of `vim.keymap.set`.