### PR TITLE
fix(main):modify which-key usage API , compatible with different whic…

### DIFF
--- a/lua/astrocore/init.lua
+++ b/lua/astrocore/init.lua
@@ -232,7 +232,13 @@ function M.which_key_register()
   if M.which_key_queue then
     local wk_avail, wk = pcall(require, "which-key")
     if wk_avail then
-      wk.add(M.which_key_queue)
+      if type(wk.register)  == "functin" then
+        wk.register(M.which_key_queue)
+      elseif type(wk.add) == "function" then
+        wk.add(M.which_key_queue)
+      else
+        vim.notify("The appropriate API for which-key was not found",vim.log.levels.ERROR)
+      end
       M.which_key_queue = nil
     end
   end


### PR DESCRIPTION
…h-key versions

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->
### Problem:
  After integrating the astrocore plugin into LunarVim and completing all configurations, I encountered the following error on every startup:

```lua
  Error executing lua callback: ...rvim/site/pack/lazy/opt/astrocore/lua/astrocore/init.lua:235: attempt to call field 'add' (a nil value)
```

### Solution:
  Through code analysis, I've made minor functional modifications to ensure compatibility between different API versions.

### Request:
  I would like to contribute these compatibility improvements through a pull request.
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
