### PR TITLE
fix(treesitter): check buffer validity before enabling features

### DIFF
--- a/lua/astrocore/treesitter.lua
+++ b/lua/astrocore/treesitter.lua
@@ -197,6 +197,8 @@ end
 ---@param bufnr? integer the buffer to enable treesitter in
 function M.enable(bufnr)
   if not bufnr then bufnr = vim.api.nvim_get_current_buf() end
+  -- Check if buffer is valid (may have been deleted during async operations)
+  if not vim.api.nvim_buf_is_valid(bufnr) then return end
   local ft = vim.bo[bufnr].filetype
   local lang = vim.treesitter.language.get_lang(ft)
   if not M.has_parser(ft) or not lang then return end


### PR DESCRIPTION
When treesitter parser installation is triggered asynchronously (e.g., via auto_install), the buffer may be deleted before the installation completes and the callback is executed. This can happen when using plugins like flatten.nvim that open files in a guest process and then delete buffers before sending them to the host.

This race condition results in an "Invalid buffer id" error when the async callback tries to enable treesitter features on a buffer that no longer exists.

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## 📖 Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
