### PR TITLE
fix(toggles): preserve treesitter syntax state

### DIFF
--- a/lua/astrocore/toggles.lua
+++ b/lua/astrocore/toggles.lua
@@ -188,11 +188,11 @@ function M.buffer_syntax(bufnr, silent)
   local treesitter = require "astrocore.treesitter"
   local astrolsp_avail, lsp_toggle = pcall(require, "astrolsp.toggles")
   if vim.bo[bufnr].syntax == "off" then
-    if treesitter.has_parser(bufnr) then vim.treesitter.start(bufnr) end
+    if treesitter.has_parser(bufnr) then treesitter.enable(bufnr) end
     vim.bo[bufnr].syntax = "on"
     if astrolsp_avail and not vim.b[bufnr].semantic_tokens then lsp_toggle.buffer_semantic_tokens(bufnr, true) end
   else
-    if treesitter.has_parser(bufnr) then vim.treesitter.stop(bufnr) end
+    treesitter.disable(bufnr)
     vim.bo[bufnr].syntax = "off"
     if astrolsp_avail and vim.b[bufnr].semantic_tokens then lsp_toggle.buffer_semantic_tokens(bufnr, true) end
   end


### PR DESCRIPTION
**Tree-sitter toggles**

- Route buffer syntax enablement and disablement through AstroCore's Tree-sitter helpers.
- Keep AstroCore's per-buffer enabled state synchronized with the active parser state.
- Record an explicit disabled state even if the parser disappears before the toggle runs.

**Validation**

- Passed StyLua, Selene, typos, Lua compilation, and diff checks.
- Passed the focused syntax-state regression on Neovim 0.11.0 and 0.12.4.
