### PR TITLE
fix: preserve core runtime state

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ AstroCore provides the core Lua API that powers [AstroNvim](https://github.com/A
 - Neovim >= 0.11
 - [lazy.nvim](https://github.com/folke/lazy.nvim)
 - [resession.nvim][resession] (_optional_)
+- For `nvim-treesitter` features: the `tree-sitter` CLI, or `mason.nvim` so AstroCore can install `tree-sitter-cli`.
 
 ## 📦 Installation
 
@@ -128,7 +129,7 @@ local opts = {
     -- first key is the type of option `vim.<first_key>`
     opt = {
       relativenumber = true, -- sets `vim.opt.relativenumber`
-      signcolumn = "auto", -- sets `vim.opt.relativenumber`
+      signcolumn = "auto", -- sets `vim.opt.signcolumn`
     },
     g = {
       -- set global `vim.g` settings here

--- a/lua/astrocore/buffer.lua
+++ b/lua/astrocore/buffer.lua
@@ -173,13 +173,13 @@ end
 ---@param force? boolean Whether or not to force close the buffers or confirm changes (default: false)
 local function mini_confirm(func, bufnr, force)
   if not force and vim.bo[bufnr].modified then
-    local bufname = vim.fn.expand "%"
+    local bufname = vim.api.nvim_buf_get_name(bufnr)
     local empty = bufname == ""
     if empty then bufname = "Untitled" end
     local confirm = vim.fn.confirm(('Save changes to "%s"?'):format(bufname), "&Yes\n&No\n&Cancel", 1, "Question")
     if confirm == 1 then
       if empty then return end
-      vim.cmd.write()
+      vim.api.nvim_buf_call(bufnr, function() vim.cmd.write() end)
     elseif confirm == 2 then
       force = true
     else
@@ -279,9 +279,8 @@ end
 function M.close_tab(tabpage)
   if #vim.api.nvim_list_tabpages() > 1 then
     tabpage = tabpage or vim.api.nvim_get_current_tabpage()
-    vim.t[tabpage].bufs = nil
-    astro.event "BufsUpdated"
     vim.cmd.tabclose(vim.api.nvim_tabpage_get_number(tabpage))
+    astro.event "BufsUpdated"
   end
 end
 

--- a/lua/astrocore/buffer/comparator.lua
+++ b/lua/astrocore/buffer/comparator.lua
@@ -48,7 +48,7 @@ end
 ---@return boolean comparison true if A is sorted before B, false if B should be sorted before A
 function M.unique_path(bufnr_a, bufnr_b) return unique_path(bufnr_a) < unique_path(bufnr_b) end
 
---- Comparator of two buffers based on modification date
+--- Comparator of two buffers based on most recent use
 ---@param bufnr_a integer buffer number A
 ---@param bufnr_b integer buffer number B
 ---@return boolean comparison true if A is sorted before B, false if B should be sorted before A

--- a/lua/astrocore/config.lua
+++ b/lua/astrocore/config.lua
@@ -11,6 +11,8 @@
 
 ---@class AstroCoreMapping: vim.api.keyset.keymap
 ---@field [1] AstroCoreMappingCmd? rhs of keymap
+---@field mode? string|string[] which-key mode(s)
+---@field group? string|fun():string which-key group label
 
 ---@alias AstroCoreMappings table<string,table<string,(AstroCoreMapping|AstroCoreMappingCmd|false)?>?>
 
@@ -149,7 +151,7 @@
 ---```
 ---@field indent AstroCoreTreesitterFeature?
 ---@field auto_install boolean? whether or not to automatically detect and install missing treesitter parsers
----@field ensure_installed string[]|"all"? a list of treesitter parsers to ensure are installed, "all" will install all parsers, "auto" will install when opening a filetype with an available parser
+---@field ensure_installed string[]|"all"|"auto"? a list of treesitter parsers to ensure are installed, "all" will install all parsers, "auto" will install when opening a filetype with an available parser
 ---Configuration of textobject mappings to create using `nvim-treesitter-textobjects`
 ---
 ---Examples:

--- a/lua/astrocore/init.lua
+++ b/lua/astrocore/init.lua
@@ -15,6 +15,8 @@ M.config = require "astrocore.config"
 ---@type table<string,table<integer,table>>
 M.user_terminals = {}
 
+local default_terminal_key = {}
+
 --- Merge extended options with a default table of options
 ---@param default? table The default table that you want to merge into
 ---@param opts? table The new options that should be merged with the default table
@@ -102,17 +104,26 @@ end
 ---@param msg string The notification body
 ---@param type integer|nil The type of the notification (:help vim.log.levels)
 ---@param opts? table The nvim-notify options to use (:help notify-options)
-function M.notify(msg, type, opts)
-  vim.schedule(function() vim.notify(msg, type, M.extend_tbl({ title = "AstroNvim" }, opts)) end)
+---@param force? boolean Whether to deliver even when notifications are disabled
+function M.notify(msg, type, opts, force)
+  if not force and vim.tbl_get(M.config, "features", "notifications") == false then return end
+  vim.schedule(function()
+    if not force and vim.tbl_get(M.config, "features", "notifications") == false then return end
+    vim.notify(msg, type, M.extend_tbl({ title = "AstroNvim" }, opts))
+  end)
 end
 
 --- Trigger an AstroNvim user event
----@param event string|vim.api.keyset_exec_autocmds The event pattern or full autocmd options (pattern always prepended with "Astro")
+---@param event string|vim.api.keyset.exec_autocmds The event pattern or full autocmd options (pattern always prepended with "Astro")
 ---@param instant? boolean Whether or not to execute instantly or schedule
 function M.event(event, instant)
   if type(event) == "string" then event = { pattern = event } end
   event = M.extend_tbl({ modeline = false }, event)
-  event.pattern = "Astro" .. event.pattern
+  if type(event.pattern) == "string" then
+    event.pattern = "Astro" .. event.pattern
+  else
+    event.pattern = vim.tbl_map(function(pattern) return "Astro" .. pattern end, event.pattern)
+  end
   if instant then
     vim.api.nvim_exec_autocmds("User", event)
   else
@@ -140,9 +151,13 @@ end
 ---@return string content the contents of the file
 function M.read_file(path)
   local fd = assert(vim.uv.fs_open(path, "r", 420))
-  local stat = assert(vim.uv.fs_fstat(fd))
-  local content = assert(vim.uv.fs_read(fd, stat.size))
-  assert(vim.uv.fs_close(fd))
+  local success, content = pcall(function()
+    local stat = assert(vim.uv.fs_fstat(fd))
+    return assert(vim.uv.fs_read(fd, stat.size))
+  end)
+  local close_success, close_err = vim.uv.fs_close(fd)
+  if not success then error(content, 0) end
+  assert(close_success, close_err)
   return content
 end
 
@@ -153,20 +168,21 @@ function M.toggle_term_cmd(opts)
   -- if a command string is provided, create a basic table for Terminal:new() options
   if type(opts) == "string" then opts = { cmd = opts } end
   opts = M.extend_tbl({ hidden = true }, opts)
+  local terminal_key = opts.cmd or default_terminal_key
   local num = vim.v.count > 0 and vim.v.count or 1
   -- if terminal doesn't exist yet, create it
-  if not terms[opts.cmd] then terms[opts.cmd] = {} end
-  if not terms[opts.cmd][num] then
+  if not terms[terminal_key] then terms[terminal_key] = {} end
+  if not terms[terminal_key][num] then
     if not opts.count then opts.count = vim.tbl_count(terms) * 100 + num end
     local on_exit = opts.on_exit
     opts.on_exit = function(...)
-      terms[opts.cmd][num] = nil
+      terms[terminal_key][num] = nil
       if on_exit then on_exit(...) end
     end
-    terms[opts.cmd][num] = require("toggleterm.terminal").Terminal:new(opts)
+    terms[terminal_key][num] = require("toggleterm.terminal").Terminal:new(opts)
   end
   -- toggle the terminal
-  terms[opts.cmd][num]:toggle()
+  terms[terminal_key][num]:toggle()
 end
 
 --- Get a plugin spec from lazy
@@ -274,22 +290,21 @@ function M.set_mappings(map_table, base)
       -- build the options for the command accordingly
       if options then
         local cmd
-        local keymap_opts = base or {}
+        local keymap_opts = (base or {}) --[[@as AstroCoreMapping]]
         if type(options) == "string" or type(options) == "function" then
           cmd = options
         else
           cmd = options[1]
-          keymap_opts = vim.tbl_deep_extend("force", keymap_opts, options)
+          keymap_opts = vim.tbl_deep_extend("force", keymap_opts, options) --[[@as AstroCoreMapping]]
           keymap_opts[1] = nil
         end
         if not cmd then -- if which-key mapping, queue it
-          ---@cast keymap_opts wk.Spec
           keymap_opts[1], keymap_opts.mode = keymap, mode
           if not keymap_opts.group then keymap_opts.group = keymap_opts.desc end
           if not M.which_key_queue then M.which_key_queue = {} end
           table.insert(M.which_key_queue, keymap_opts)
         else -- if not which-key mapping, set it
-          vim.keymap.set(mode, keymap, cmd, keymap_opts)
+          vim.keymap.set(mode, keymap, cmd, keymap_opts --[[@as vim.keymap.set.Opts]])
         end
       end
     end
@@ -312,7 +327,7 @@ function M.delete_url_match(win)
 end
 
 --- Add syntax matching rules for highlighting URLs/URIs
----@param win? integer the window id to remove url highlighting in (default: current window)
+---@param win? integer the window id to add url highlighting in (default: current window)
 function M.set_url_match(win)
   if not win then win = vim.api.nvim_get_current_win() end
   M.delete_url_match(win)
@@ -327,13 +342,24 @@ end
 ---@param show_error? boolean Whether or not to show an unsuccessful command as an error to the user
 ---@return string|nil result The result of a successfully executed command or nil
 function M.cmd(cmd, show_error)
-  if type(cmd) == "string" then cmd = { cmd } end
-  if vim.fn.has "win32" == 1 then cmd = vim.list_extend({ "cmd.exe", "/C" }, cmd) end
+  local display_cmd
+  if type(cmd) == "string" then
+    display_cmd = cmd
+  else
+    display_cmd = table.concat(cmd, " ")
+  end
+  if vim.fn.has "win32" == 1 then
+    if type(cmd) == "string" then
+      cmd = { "cmd.exe", "/C", cmd }
+    else
+      cmd = vim.list_extend({ "cmd.exe", "/C" }, cmd)
+    end
+  end
   local result = vim.fn.system(cmd)
   local success = vim.api.nvim_get_vvar "shell_error" == 0
   if not success and (show_error == nil or show_error) then
     vim.api.nvim_echo(
-      { { ("Error running command %s\nError message:\n%s"):format(table.concat(cmd, " "), result) } },
+      { { ("Error running command %s\nError message:\n%s"):format(display_cmd, result) } },
       true,
       { err = true }
     )
@@ -343,7 +369,7 @@ end
 
 --- Get the first worktree that a file belongs to
 ---@param file? string the file to check, defaults to the current file
----@param worktrees table<string, string>[]? an array like table of worktrees with entries `toplevel` and `gitdir`, default retrieves from `vim.g.git_worktrees`
+---@param worktrees table<string, string>[]? an array like table of worktrees with entries `toplevel` and `gitdir`, defaults to `config.git_worktrees`
 ---@return table<string, string>|nil worktree a table specifying the `toplevel` and `gitdir` of a worktree or nil if not found
 function M.file_worktree(file, worktrees)
   worktrees = worktrees or M.config.git_worktrees
@@ -396,8 +422,12 @@ end
 function M.with_file(filename, mode, callback, on_error)
   local file, errmsg = io.open(filename, mode)
   if file then
-    if callback then callback(file) end
+    local success, err = true, nil
+    if callback then
+      success, err = pcall(callback, file)
+    end
     file:close()
+    if not success then error(err, 0) end
   elseif errmsg and on_error then
     on_error(errmsg)
   end
@@ -430,22 +460,6 @@ function M.rename_file(opts)
   from = vim.fn.fnamemodify(from, ":p")
 
   local from_bufnr = vim.fn.bufnr(from)
-  if from_bufnr >= 0 and vim.bo[from_bufnr].modified then
-    local write_confirm = opts.save ~= nil and (opts.save and 1 or 2)
-      or vim.fn.confirm(
-        ('Save changes to "%s"?'):format(vim.fn.fnamemodify(from, ":.")),
-        "&Yes\n&No\n&Cancel",
-        1,
-        "Question"
-      )
-    -- write_confirm: 1 saves, 2 doesn't save, anything else aborts
-    if write_confirm == 1 then
-      vim.api.nvim_buf_call(from_bufnr, function() vim.cmd.write { mods = { silent = true } } end)
-    elseif write_confirm ~= 2 then
-      M.notify(("Renaming cancelled:\n`%s`"):format(vim.fn.fnamemodify(from, ":.")), vim.log.levels.INFO)
-      return
-    end
-  end
 
   if not vim.uv.fs_stat(from) then
     M.notify(("File does not exists:\n`%s`"):format(vim.fn.fnamemodify(from, ":.")), vim.log.levels.ERROR)
@@ -453,10 +467,27 @@ function M.rename_file(opts)
   end
 
   local _rename_file = function(to)
+    if vim.fn.isabsolutepath(to) == 0 then to = vim.fs.joinpath(vim.fs.dirname(from), to) end
     to = vim.fn.fnamemodify(to, ":p")
     if not opts.force and vim.uv.fs_stat(to) then
       M.notify(("File already exists:\n`%s`\n\n"):format(vim.fn.fnamemodify(to, ":.")), vim.log.levels.ERROR)
       return
+    end
+    if from_bufnr >= 0 and vim.api.nvim_buf_is_valid(from_bufnr) and vim.bo[from_bufnr].modified then
+      local write_confirm = opts.save ~= nil and (opts.save and 1 or 2)
+        or vim.fn.confirm(
+          ('Save changes to "%s"?'):format(vim.fn.fnamemodify(from, ":.")),
+          "&Yes\n&No\n&Cancel",
+          1,
+          "Question"
+        )
+      -- write_confirm: 1 saves, 2 doesn't save, anything else aborts
+      if write_confirm == 1 then
+        vim.api.nvim_buf_call(from_bufnr, function() vim.cmd.write { mods = { silent = true } } end)
+      elseif write_confirm ~= 2 then
+        M.notify(("Renaming cancelled:\n`%s`"):format(vim.fn.fnamemodify(from, ":.")), vim.log.levels.INFO)
+        return
+      end
     end
     vim.fn.mkdir(vim.fs.dirname(to), "p")
     local rename_data = { from = from, to = to }
@@ -464,7 +495,7 @@ function M.rename_file(opts)
     local success = vim.fn.rename(from, to) == 0
     rename_data.success = success
     if success then
-      if from_bufnr >= 0 then
+      if from_bufnr >= 0 and vim.api.nvim_buf_is_valid(from_bufnr) then
         local to_bufnr = vim.fn.bufadd(to)
         vim.bo[to_bufnr].buflisted = true
         for _, win in ipairs(vim.fn.win_findbuf(from_bufnr)) do
@@ -492,19 +523,23 @@ function M.rename_file(opts)
     _rename_file(opts.to)
   else
     local root = vim.fn.getcwd()
-    if from:find(root, 1, true) ~= 1 then root = vim.fn.fnamemodify(from, ":p:h") end
-    local prefix = from:sub(#root + 2)
+    local prefix = vim.fs.relpath(root, from)
+    if not prefix then
+      root = vim.fs.dirname(from)
+      prefix = vim.fs.basename(from)
+    end
     vim.ui.input({
       prompt = "New File Name: ",
       default = prefix,
       completion = "file",
     }, function(input)
-      if input and input ~= "" and input ~= prefix then _rename_file(vim.fs.normalize(root .. "/" .. input)) end
+      if input and input ~= "" and input ~= prefix then _rename_file(vim.fs.joinpath(root, input)) end
     end)
   end
 end
 
 local key_cache = {} ---@type { [string]: string }
+local on_key_namespaces = {}
 --- Normalize a mappings table to use official keycode casing
 ---@param mappings AstroCoreMappings?
 function M.normalize_mappings(mappings)
@@ -578,12 +613,19 @@ function M.setup(opts)
   if M.config.filetypes then vim.filetype.add(M.config.filetypes) end
 
   -- on_key hooks
+  for _, namespace in pairs(on_key_namespaces) do
+    vim.on_key(nil, namespace)
+  end
+  on_key_namespaces = {}
   for namespace, funcs in pairs(M.config.on_keys) do
     if funcs then
       local ns = vim.api.nvim_create_namespace(namespace)
-      for _, func in ipairs(funcs) do
-        vim.on_key(func, ns)
-      end
+      on_key_namespaces[namespace] = ns
+      vim.on_key(function(key)
+        for _, func in ipairs(funcs) do
+          func(key)
+        end
+      end, ns)
     end
   end
 
@@ -685,12 +727,7 @@ function M.setup(opts)
         group = group,
         desc = "Root detection on LSP attach",
         callback = function(args)
-          if root_config.autochdir then
-            local server = assert(vim.lsp.get_client_by_id(args.data.client_id)).name
-            if not vim.tbl_contains(vim.tbl_get(root_config, "ignore", "servers") or {}, server) then
-              require("astrocore.rooter").root(args.buf)
-            end
-          end
+          if root_config.autochdir then require("astrocore.rooter").root(args.buf) end
         end,
       })
     end

--- a/lua/astrocore/rooter.lua
+++ b/lua/astrocore/rooter.lua
@@ -43,10 +43,11 @@ function M.detectors.lsp(config)
     local bufpath = M.bufpath(bufnr)
     if not bufpath then return {} end
     local roots = {} ---@type string[]
-    for _, client in ipairs(vim.lsp.get_clients { buffer = bufnr }) do
+    for _, client in ipairs(vim.lsp.get_clients { bufnr = bufnr }) do
       if not server_filter or not server_filter(client) then
         if client.root_dir then table.insert(roots, client.root_dir) end
-        for _, ws in pairs(client.config.workspace_folders or {}) do
+        local workspace_folders = client.workspace_folders or (client.config and client.config.workspace_folders) or {}
+        for _, ws in pairs(workspace_folders) do
           table.insert(roots, vim.uri_to_fname(ws.uri))
         end
       end
@@ -54,7 +55,8 @@ function M.detectors.lsp(config)
     local found_lsp_roots = {}
     return vim.tbl_filter(function(path)
       path = M.normpath(path)
-      if path and bufpath:find(path, 1, true) == 1 then
+      local prefix = path:sub(-1) == "/" and path or path .. "/"
+      if bufpath == path or bufpath:find(prefix, 1, true) == 1 then
         if not found_lsp_roots[path] then
           found_lsp_roots[path] = true
           return true
@@ -88,7 +90,7 @@ function M.bufpath(bufnr) return M.realpath(vim.api.nvim_buf_get_name(bufnr)) en
 
 --- Resolve a given path
 ---@param path? string the path to resolve
----@return string? the resolved path
+---@return string? path the resolved path
 function M.realpath(path)
   if not path or path == "" then return nil end
   return M.normpath(vim.uv.fs_realpath(path) or path)
@@ -108,8 +110,11 @@ function M.normpath(path)
     if home:sub(-1) == "\\" or home:sub(-1) == "/" then home = home:sub(1, -2) end
     path = home .. path:sub(2)
   end
-  path = path:gsub("\\", "/"):gsub("/+", "/")
-  return (path:sub(-1) == "/" and path ~= "/") and path:sub(1, -2) or path
+  path = path:gsub("\\", "/")
+  local is_unc_path = path:sub(1, 2) == "//"
+  path = path:gsub("/+", "/")
+  if is_unc_path then path = "/" .. path end
+  return (path:sub(-1) == "/" and path ~= "/" and not path:match "^%a:/$") and path:sub(1, -2) or path
 end
 
 --- Resolve the root detection function for a given spec
@@ -139,7 +144,7 @@ function M.detect(bufnr, all, config)
   if not require("astrocore.buffer").is_valid(bufnr) then return ret end
 
   local path = M.bufpath(bufnr)
-  if path and M.is_excluded(path) then return ret end
+  if path and M.is_excluded(path, config) then return ret end
 
   for _, spec in ipairs(config.detector or {}) do
     local paths = M.resolve(spec, config)(bufnr)
@@ -180,7 +185,9 @@ function M.info(config)
           ("%s`%s` *(%s*)%s"):format(
             surround,
             path,
-            type(root.spec) == "table" and table.concat(root.spec --[=[@as string[]]=], ", ") or root.spec,
+            type(root.spec) == "table" and table.concat(root.spec --[=[@as string[]]=], ", ")
+              or type(root.spec) == "function" and vim.inspect(root.spec)
+              or root.spec,
             surround
           )
         )
@@ -213,18 +220,26 @@ function M.set_pwd(root, config)
   local path = root.paths[1]
   if path ~= nil then
     if vim.fn.has "win32" > 0 then path = path:gsub("\\", "/") end
-    if vim.fn.getcwd() ~= path then
-      if config.scope == "global" then
-        vim.api.nvim_set_current_dir(path)
-      elseif config.scope == "tab" then
-        vim.cmd.tchdir(path)
-      elseif config.scope == "win" then
-        vim.cmd.lchdir(path)
-      else
-        vim.api.nvim_echo({ { ("Unable to parse scope: %s"):format(config.scope) } }, true, { err = true })
-        return false
-      end
+    local cwd, has_local_dir, set_dir
+    if config.scope == "global" then
+      cwd = vim.fn.getcwd(-1, -1)
+      has_local_dir = true
+      set_dir = vim.api.nvim_set_current_dir
+    elseif config.scope == "tab" then
+      cwd = vim.fn.getcwd(-1, 0)
+      has_local_dir = vim.fn.haslocaldir(-1, 0) == 1
+      set_dir = vim.cmd.tchdir
+    elseif config.scope == "win" then
+      cwd = vim.fn.getcwd(0, 0)
+      has_local_dir = vim.fn.haslocaldir(0, 0) == 1
+      set_dir = vim.cmd.lchdir
+    else
+      vim.api.nvim_echo({ { ("Unable to parse scope: %s"):format(config.scope) } }, true, { err = true })
+      return false
+    end
 
+    if cwd ~= path or not has_local_dir then
+      set_dir(path)
       if config.notify then notify(("Set CWD to `%s`"):format(path)) end
     end
     return true

--- a/lua/astrocore/toggles.lua
+++ b/lua/astrocore/toggles.lua
@@ -10,7 +10,9 @@
 local M = {}
 
 local function bool2str(bool) return bool and "on" or "off" end
-local function ui_notify(silent, ...) return not silent and require("astrocore").notify(...) end
+local function ui_notify(silent, message, force)
+  if not silent then require("astrocore").notify(message, nil, nil, force) end
+end
 
 --- Toggle rooter autochdir
 ---@param silent? boolean if true then do not send a notification
@@ -28,8 +30,10 @@ end
 ---@param silent? boolean if true then do not send a notification
 function M.notifications(silent)
   local features = assert(require("astrocore").config.features)
-  features.notifications = not features.notifications
-  ui_notify(silent, ("Notifications %s"):format(bool2str(features.notifications)))
+  local enabled = not features.notifications
+  if enabled then features.notifications = true end
+  ui_notify(silent, ("Notifications %s"):format(bool2str(enabled)), not enabled)
+  features.notifications = enabled
 end
 
 --- Toggle autopairs
@@ -42,7 +46,7 @@ function M.autopairs(silent)
     else
       autopairs.disable()
     end
-    require("astrocore").config.features.autopairs = autopairs.state.disabled
+    require("astrocore").config.features.autopairs = not autopairs.state.disabled
     ui_notify(silent, ("autopairs %s"):format(bool2str(not autopairs.state.disabled)))
   else
     ui_notify(silent, "autopairs not available")
@@ -98,7 +102,7 @@ end
 function M.statusline(silent)
   local laststatus = vim.opt.laststatus:get()
   local status
-  if laststatus == 0 then
+  if laststatus == 0 or laststatus == 1 then
     vim.opt.laststatus = 2
     status = "local"
   elseif laststatus == 2 then
@@ -179,24 +183,37 @@ function M.wrap(silent)
   ui_notify(silent, ("wrap %s"):format(bool2str(vim.wo.wrap)))
 end
 
---- Toggle syntax highlighting and treesitter
+--- Toggle syntax highlighting, treesitter, and LSP semantic tokens
 ---@param bufnr? integer the buffer to toggle syntax on
 ---@param silent? boolean if true then do not send a notification
 function M.buffer_syntax(bufnr, silent)
   -- HACK: this should just be `bufnr = bufnr or 0` but it looks like `vim.treesitter.stop` has a bug with `0` being current
-  bufnr = (bufnr and bufnr ~= 0) and bufnr or vim.api.nvim_win_get_buf(0)
+  bufnr = (bufnr and bufnr ~= 0) and bufnr or vim.api.nvim_get_current_buf()
   local treesitter = require "astrocore.treesitter"
   local astrolsp_avail, lsp_toggle = pcall(require, "astrolsp.toggles")
-  if vim.bo[bufnr].syntax == "off" then
+  local semantic_tokens_enabled = vim.b[bufnr].semantic_tokens
+  if vim.lsp.semantic_tokens.enable then
+    semantic_tokens_enabled = vim.lsp.semantic_tokens.is_enabled { bufnr = bufnr }
+  end
+  local enable = vim.bo[bufnr].syntax == "off"
+  if enable then
+    local syntax = vim.b[bufnr].astrocore_syntax
+    local semantic_tokens_disabled = vim.b[bufnr].astrocore_semantic_tokens_disabled
+    vim.b[bufnr].astrocore_syntax = nil
+    vim.b[bufnr].astrocore_semantic_tokens_disabled = nil
+    vim.bo[bufnr].syntax = syntax or vim.bo[bufnr].filetype
     if treesitter.has_parser(bufnr) then treesitter.enable(bufnr) end
-    vim.bo[bufnr].syntax = "on"
-    if astrolsp_avail and not vim.b[bufnr].semantic_tokens then lsp_toggle.buffer_semantic_tokens(bufnr, true) end
+    if astrolsp_avail and semantic_tokens_disabled and not semantic_tokens_enabled then
+      lsp_toggle.buffer_semantic_tokens(bufnr, true)
+    end
   else
+    vim.b[bufnr].astrocore_syntax = vim.bo[bufnr].syntax
     treesitter.disable(bufnr)
     vim.bo[bufnr].syntax = "off"
-    if astrolsp_avail and vim.b[bufnr].semantic_tokens then lsp_toggle.buffer_semantic_tokens(bufnr, true) end
+    vim.b[bufnr].astrocore_semantic_tokens_disabled = astrolsp_avail and semantic_tokens_enabled
+    if vim.b[bufnr].astrocore_semantic_tokens_disabled then lsp_toggle.buffer_semantic_tokens(bufnr, true) end
   end
-  ui_notify(silent, ("syntax %s"):format(vim.bo[bufnr].syntax))
+  ui_notify(silent, ("syntax %s"):format(bool2str(enable)))
 end
 
 --- Toggle URL/URI syntax highlighting rules
@@ -211,13 +228,12 @@ function M.url_match(silent)
   ui_notify(silent, ("URL highlighting %s"):format(bool2str(features.highlighturl)))
 end
 
-local last_active_foldcolumn
 --- Toggle foldcolumn=0|1
 ---@param silent? boolean if true then do not send a notification
 function M.foldcolumn(silent)
   local curr_foldcolumn = vim.wo.foldcolumn
-  if curr_foldcolumn ~= "0" then last_active_foldcolumn = curr_foldcolumn end
-  vim.wo.foldcolumn = curr_foldcolumn == "0" and (last_active_foldcolumn or "1") or "0"
+  if curr_foldcolumn ~= "0" then vim.w.astrocore_foldcolumn = curr_foldcolumn end
+  vim.wo.foldcolumn = curr_foldcolumn == "0" and (vim.w.astrocore_foldcolumn or "1") or "0"
   ui_notify(silent, ("foldcolumn=%s"):format(vim.wo.foldcolumn))
 end
 

--- a/lua/astrocore/treesitter.lua
+++ b/lua/astrocore/treesitter.lua
@@ -19,7 +19,32 @@ local queries = {}
 local captures = {}
 
 local enabled = {}
+local highlights = {}
 local indentexprs = {}
+local textobject_mappings = {}
+local treesitter_indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+
+local function normalize_key(key) return vim.fn.keytrans(vim.api.nvim_replace_termcodes(key, true, true, true)) end
+
+local function restore_owned_indentexpr(bufnr)
+  if indentexprs[bufnr] ~= nil then
+    if vim.bo[bufnr].indentexpr == treesitter_indentexpr then vim.bo[bufnr].indentexpr = indentexprs[bufnr] end
+    indentexprs[bufnr] = nil
+  end
+end
+
+local function clear_textobject_mappings(bufnr)
+  if vim.api.nvim_buf_is_valid(bufnr) then
+    for mode, mappings in pairs(textobject_mappings[bufnr] or {}) do
+      for _, mapping in ipairs(vim.api.nvim_buf_get_keymap(bufnr, mode)) do
+        if mappings[normalize_key(mapping.lhs)] == mapping.callback then
+          vim.api.nvim_buf_del_keymap(bufnr, mode, mapping.lhs)
+        end
+      end
+    end
+  end
+  textobject_mappings[bufnr] = nil
+end
 
 --- Configure the keymap modes for each textobject type
 M.textobject_modes = {
@@ -35,7 +60,7 @@ function M.installed(update)
   if update then
     local treesitter_avail, treesitter = pcall(require, "nvim-treesitter")
     if treesitter_avail then
-      installed, queries = {}, {}
+      installed, queries, captures = {}, {}, {}
       for _, lang in ipairs(treesitter.get_installed "parsers") do
         installed[lang] = true
       end
@@ -61,13 +86,13 @@ function M.available()
 end
 
 --- Install the provided parsers with `nvim-treesitter`
----@param languages? "all"|string[] a list of languages to install, automatically detect the current language to install, or install all available parsers (default: "auto")
+---@param languages? "auto"|"all"|string[] a list of languages to install, automatically detect the current language to install, or install all available parsers (default: "auto")
 ---@param cb? function optional callback function to execute after installation finishes
 function M.install(languages, cb)
   local patch_func = require("astrocore").patch_func
   local treesitter_avail, treesitter = pcall(require, "nvim-treesitter")
   if not treesitter_avail then return end
-  if not languages then
+  if not languages or languages == "auto" then
     local lang = vim.treesitter.language.get_lang(vim.bo[vim.api.nvim_get_current_buf()].filetype)
     languages = M.available()[lang] and { lang } or {}
   elseif languages == "all" then
@@ -89,7 +114,7 @@ end
 ---@param lang string the parser language to check against
 ---@param query string the query type to check for support of
 ---@param capture string the capture type to check for support of
----@return boolean # whether or not a query is supported by the given parser
+---@return boolean # whether or not a capture is supported by the given parser
 function M.has_capture(lang, query, capture)
   local key = lang .. ":" .. query
   if captures[key] == nil then
@@ -127,29 +152,51 @@ end
 
 local function _setup()
   require("astrocore").on_load("nvim-treesitter", function()
+    available = nil
     M.installed(true)
     M.install(config.ensure_installed)
   end)
 
-  vim.api.nvim_create_autocmd("FileType", {
-    group = vim.api.nvim_create_augroup("astrocore_treesitter", { clear = true }),
-    desc = "Automatically detect available treesitter parsers and enable necessary features",
-    callback = function(args)
-      if enabled[args.buf] == false then return end
-      local lang = vim.treesitter.language.get_lang(vim.bo[args.buf].filetype)
-      if not lang then return end
-      local _enabled = config.enabled
-      if type(_enabled) == "function" then _enabled = _enabled(lang, args.buf) end
-      if _enabled then
-        if not installed_checked then M.installed(true) end
-        if not M.has_parser(args.match) then
-          if config.auto_install then M.install(nil, function() M.enable(args.buf) end) end
-        else
-          M.enable(args.buf)
+  local group = vim.api.nvim_create_augroup("astrocore_treesitter", { clear = true })
+  local function reconcile_buffer(args, allow_install)
+    if enabled[args.buf] == false then return end
+    local lang = vim.treesitter.language.get_lang(vim.bo[args.buf].filetype)
+    if not lang then
+      M.disable(args.buf)
+      enabled[args.buf] = nil
+      return
+    end
+    local _enabled = config.enabled
+    if type(_enabled) == "function" then _enabled = _enabled(lang, args.buf) end
+    if _enabled then
+      if not installed_checked then M.installed(true) end
+      if not M.has_parser(args.buf) then
+        M.disable(args.buf)
+        enabled[args.buf] = nil
+        if allow_install ~= false and (config.auto_install or config.ensure_installed == "auto") then
+          M.install(M.available()[lang] and { lang } or {}, function()
+            if vim.api.nvim_buf_is_valid(args.buf) then reconcile_buffer(args, false) end
+          end)
         end
       else
-        M.disable(args.buf)
+        M.enable(args.buf)
       end
+    else
+      M.disable(args.buf)
+      enabled[args.buf] = nil
+    end
+  end
+  vim.api.nvim_create_autocmd("FileType", {
+    group = group,
+    desc = "Automatically detect available treesitter parsers and enable necessary features",
+    callback = reconcile_buffer,
+  })
+  vim.api.nvim_create_autocmd({ "BufDelete", "BufWipeout" }, {
+    group = group,
+    desc = "Clear deleted buffer treesitter state",
+    callback = function(args)
+      enabled[args.buf], highlights[args.buf], indentexprs[args.buf] = nil, nil, nil
+      textobject_mappings[args.buf] = nil
     end,
   })
 end
@@ -201,7 +248,11 @@ end
 function M.enable(bufnr)
   if not bufnr then bufnr = vim.api.nvim_get_current_buf() end
   -- Check if buffer is valid (may have been deleted during async operations)
-  if not vim.api.nvim_buf_is_valid(bufnr) then return end
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    textobject_mappings[bufnr] = nil
+    return
+  end
+  clear_textobject_mappings(bufnr)
   local ft = vim.bo[bufnr].filetype
   local lang = vim.treesitter.language.get_lang(ft)
   if not M.has_parser(ft) or not lang then return end
@@ -220,12 +271,19 @@ function M.enable(bufnr)
   end
 
   -- highlighting
-  if feature_enabled("highlight", "highlights") then pcall(vim.treesitter.start, bufnr) end
+  if feature_enabled("highlight", "highlights") then
+    highlights[bufnr] = pcall(vim.treesitter.start, bufnr)
+  elseif highlights[bufnr] then
+    pcall(vim.treesitter.stop, bufnr)
+    highlights[bufnr] = nil
+  end
 
   -- indents
   if feature_enabled("indent", "indents") then
-    indentexprs[bufnr] = vim.bo[bufnr].indentexpr
-    vim.bo[bufnr].indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+    if vim.bo[bufnr].indentexpr ~= treesitter_indentexpr then indentexprs[bufnr] = vim.bo[bufnr].indentexpr end
+    vim.bo[bufnr].indentexpr = treesitter_indentexpr
+  else
+    restore_owned_indentexpr(bufnr)
   end
 
   -- if folds are present force update of folds after loading
@@ -241,12 +299,13 @@ function M.enable(bufnr)
         for key, opts in pairs(keys) do
           local group = opts.group or "textobjects"
           if M.has_capture(lang, group, string.sub(opts.query, 2)) then
-            vim.keymap.set(
-              mode,
-              key,
-              function() require("nvim-treesitter-textobjects." .. type)[method](opts.query, group) end,
-              { buffer = bufnr, desc = opts.desc, silent = true }
-            )
+            local callback = function() require("nvim-treesitter-textobjects." .. type)[method](opts.query, group) end
+            for _, map_mode in ipairs(mode) do
+              vim.keymap.set(map_mode, key, callback, { buffer = bufnr, desc = opts.desc, silent = true })
+              textobject_mappings[bufnr] = textobject_mappings[bufnr] or {}
+              textobject_mappings[bufnr][map_mode] = textobject_mappings[bufnr][map_mode] or {}
+              textobject_mappings[bufnr][map_mode][normalize_key(key)] = callback
+            end
           end
         end
       end
@@ -258,11 +317,18 @@ end
 ---@param bufnr? integer the buffer to disable treesitter in
 function M.disable(bufnr)
   if not bufnr then bufnr = vim.api.nvim_get_current_buf() end
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    enabled[bufnr], highlights[bufnr], indentexprs[bufnr] = nil, nil, nil
+    textobject_mappings[bufnr] = nil
+    return
+  end
   enabled[bufnr] = false
   pcall(vim.treesitter.stop, bufnr)
-  if indentexprs[bufnr] then vim.bo[bufnr].indentexpr = indentexprs[bufnr] end
+  highlights[bufnr] = nil
+  restore_owned_indentexpr(bufnr)
+  clear_textobject_mappings(bufnr)
   vim.schedule(function()
-    if vim.api.nvim_get_current_buf() == bufnr then vim.cmd "normal! zx" end
+    if vim.api.nvim_get_current_buf() == bufnr and vim.bo[bufnr].buftype ~= "terminal" then vim.cmd "normal! zx" end
   end)
 end
 

--- a/lua/resession/extensions/astrocore.lua
+++ b/lua/resession/extensions/astrocore.lua
@@ -13,7 +13,7 @@ function M.on_save(opts)
   -- save tab scoped buffers and buffer numbers from buffer name
   for new_tabpage, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
     if tabpage == opts.tabpage then data.tabpage = new_tabpage end
-    data.tabs[new_tabpage] = vim.t[tabpage].bufs
+    data.tabs[new_tabpage] = vim.t[tabpage].bufs or {}
     for _, bufnr in ipairs(data.tabs[new_tabpage]) do
       data.bufnrs[vim.api.nvim_buf_get_name(bufnr)] = bufnr
     end
@@ -33,17 +33,22 @@ function M.on_post_load(data)
   -- build new tab scoped buffer lists
   if not data.tabpage then
     for tabpage, tabs in pairs(data.tabs) do
-      local bufs = {}
-      for _, bufnr in pairs(tabs) do
-        table.insert(bufs, new_bufnrs[bufnr])
+      if new_tabpages[tabpage] then
+        local bufs = {}
+        for _, bufnr in ipairs(tabs) do
+          local new_bufnr = new_bufnrs[bufnr]
+          if new_bufnr then table.insert(bufs, new_bufnr) end
+        end
+        vim.t[new_tabpages[tabpage]].bufs = bufs
       end
-      vim.t[new_tabpages[tabpage]].bufs = bufs
     end
   else
-    vim.t.bufs = {}
-    for _, bufnr in pairs(data.tabs[data.tabpage]) do
-      table.insert(vim.t.bufs, new_bufnrs[bufnr])
+    local bufs = {}
+    for _, bufnr in ipairs(data.tabs[data.tabpage] or {}) do
+      local new_bufnr = new_bufnrs[bufnr]
+      if new_bufnr then table.insert(bufs, new_bufnr) end
     end
+    vim.t.bufs = bufs
   end
 
   local buf_utils = require "astrocore.buffer"


### PR DESCRIPTION
**Runtime state**

- Preserve rooter, session, Tree-sitter, buffer, and toggle state across reloads and lifecycle transitions.
- Handle stale files, Windows paths, terminal folding, and command variants without changing the public API.

**Documentation and types**

- Correct configuration docs and align mapping and command annotations with supported values.

**Validation**

- Passed StyLua, Selene, typos, diff checks, focused runtime tests, and a full tracked-source LuaLS audit.
